### PR TITLE
Example plugin

### DIFF
--- a/examples/extensible-interface-files/core-plugins/basic-example/Example.hs
+++ b/examples/extensible-interface-files/core-plugins/basic-example/Example.hs
@@ -1,29 +1,172 @@
 module Example where
 
+import Bag
 import GHC.Plugins
-import GHC.Iface.Load
+import GHC.Iface.Load hiding (loadCore)
+import GHC.Iface.Syntax
+import GHC.IfaceToCore hiding (tcIfaceModGuts)
 import GHC.Tc.Types
 import GHC.Tc.Utils.Monad
-
-import Control.Monad
-
+import GHC.Hs.Binds
+import GHC.Hs.Extension
+import GHC.Core.ConLike
+import Maybes as M
+import GHC.Iface.Env
+import GHC.Iface.Binary
+import GHC.Core.InstEnv
+import GHC.Core.FamInstEnv
 
 plugin :: Plugin
-plugin = defaultPlugin { installCoreToDos = corePlugin }
+plugin = defaultPlugin { typeCheckResultAction = corePlugin }
 
 
-corePlugin :: CorePlugin
-corePlugin _ = liftIfL . mapM inlineCore
+corePlugin :: [CommandLineOption] -> ModSummary -> TcGblEnv -> TcM TcGblEnv
+corePlugin _ _mod_summary gbl = initIfaceTcRn $ do
+  hsc_env <- getTopEnv
+
+  liftIO $ putStrLn $ showSDoc (hsc_dflags hsc_env) (ppr (mgModSummaries $ hsc_mod_graph hsc_env))
+
+  let mod_summary = (mgModSummaries $ hsc_mod_graph hsc_env) !! 1
+
+  do
+    let iface_path = msHiFilePath mod_summary
+    read_result <- readIface (ms_mod mod_summary) iface_path
+    case read_result of
+        M.Failed err -> liftIO $ putStrLn "No iface"
+        M.Succeeded iface -> do
+          liftIO $ do
+             core <- initIfaceLoad hsc_env $ do
+               gbl <- getGblEnv
+               case if_rec_types gbl of
+                 Just (mod, get_type_env) -> do
+                   liftIO $ putStrLn "get_type_env"
+                   env <- get_type_env
+                   liftIO $ putStrLn $ showSDoc (hsc_dflags hsc_env) (ppr mod)
+                   liftIO $ putStrLn $ showSDoc (hsc_dflags hsc_env) (ppr env)
+                 Nothing -> liftIO $ putStrLn "No get_type_env"
+               liftIO $ putStrLn $ showSDoc (hsc_dflags hsc_env) (ppr mod_summary)
+               liftIO $ putStrLn "Interface"
+               initIfaceLcl (ms_mod mod_summary) (text "CORE") False $ do
+                 liftIO $ putStrLn "init"
+                 lcl <- getLclEnv
+                 liftIO $ putStrLn "lcl"
+                 liftIO $ putStrLn $ showSDoc (hsc_dflags hsc_env) (ppr (if_id_env lcl))
+                 liftIO $ putStrLn "id_env"
+                 loadCore iface
+             putStrLn $ "Loaded core:"
+             case core of
+               Just c -> print $ showSDoc (hsc_dflags hsc_env) (ppr (mg_binds c))
+               Nothing -> putStrLn "No core field"
+
+  binds' <- inlineCore (tcg_binds gbl)
+  return $ gbl { tcg_binds = binds' }
 
 
-liftIfL :: IfL a -> CoreM a
-liftIfL m = do
-  env <- getHscEnv
-  mod <- getModule -- I think this is meant to be the module that is the source of the inlinings, not the current module
-  liftIO $
-    initIfaceLoad env $ -- This may have to load all dependencies, rather than the current module
-    initIfaceLcl mod (text "ExamplePlugin") False m
+-- A `Bag` is an unordered collection with duplicates, and the module is included in GHC
+inlineCore :: Bag (Located (HsBind GhcTc)) -> IfG (Bag (Located (HsBind GhcTc)))
+inlineCore = mapM inlineLocBind
 
 
-inlineCore :: CoreToDo -> IfL CoreToDo
-inlineCore = return
+-- We don't need source location information for inlining
+inlineLocBind :: Located (HsBind GhcTc) -> IfG (Located (HsBind GhcTc))
+inlineLocBind = mapM inlineBind
+
+
+-- The real binding, indexed by the `GhcPass 'TypeChecked` type
+inlineBind :: HsBind GhcTc -> IfG (HsBind GhcTc)
+inlineBind x@FunBind{}    = return x
+inlineBind x@PatBind{}    = return x
+inlineBind x@VarBind{}    = return x
+inlineBind x@AbsBinds{}   = return x
+inlineBind x@PatSynBind{} = return x
+
+
+
+-------------------------------------------------------------------------------
+
+loadCore :: ModIface -> IfL (Maybe ModGuts)
+loadCore iface = do
+  ncu <- mkNameCacheUpdater
+  mapM tcIfaceModGuts =<< liftIO (readIfaceFieldWith "ghc/core" (getWithUserData ncu) iface)
+
+tcIfaceBinding :: Module -> SrcSpan -> (Bool, IfaceBinding) -> IfL (Maybe (Bind Id))
+tcIfaceBinding mod loc ibind = do
+  bind <- tryAllM $ tcIfaceBinding' mod loc ibind
+  case bind of
+    Left _ -> return Nothing
+    Right b -> do
+        let (NonRec n _) = b
+        liftIO $ putStrLn (nameStableString $ idName n)
+        return $ Just b
+
+tcIfaceBinding' :: Module -> SrcSpan -> (Bool, IfaceBinding) -> IfL (Bind Id)
+tcIfaceBinding' _   _    (_p, (IfaceRec _)) = panic "tcIfaceBinding: expected NonRec at top level"
+tcIfaceBinding' mod loc b@(p, IfaceNonRec (IfLetBndr fs ty info ji) rhs) = do
+  name <- lookupIfaceTop (mkVarOccFS fs)
+
+
+  -- name    <- newGlobalBinder mod (mkVarOccFS fs) loc
+
+  ty'     <- tcIfaceType ty
+  -- id_info <- tcIdInfo False TopLevel name ty' info
+  let id = mkExportedVanillaId name ty'
+             `asJoinId_maybe` tcJoinInfo ji
+
+
+  liftIO $ putStrLn "-----------------------------"
+  liftIO $ print (nameStableString name, isInternalName name, isExternalName name, isSystemName name, isWiredInName name)
+  liftIO $ putStrLn "------------"
+  dflags <- getDynFlags
+  -- Env env _ _ _ <- getEnv
+  -- liftIO $ do
+  --   nc <- readIORef $ hsc_NC env
+  --   putStrLn $ showSDoc dflags (ppr $ nsNames nc)
+  --   return ()
+
+
+  liftIO $ putStrLn $ showSDoc dflags (ppr rhs)
+  rhs' <- tcIfaceExpr rhs
+  liftIO $ putStrLn "------------"
+  liftIO $ putStrLn $ showSDoc dflags (ppr rhs')
+  -- liftIO $ putStrLn "------------"
+  -- liftIO $ print (b == toIfaceBinding (NonRec id rhs'))
+  liftIO $ putStrLn "-----------------------------"
+  return (NonRec id rhs')
+
+-- tcIfaceBinding' (IfaceRec pairs)
+--   = do { ids <- mapM tc_rec_bndr (map fst pairs)
+--        ; extendIfaceIdEnv ids $ do
+--        { pairs' <- zipWithM tc_pair pairs ids
+--        ; return (Rec pairs') } }
+--  where
+--    tc_rec_bndr (IfLetBndr fs ty _ ji)
+--      = do { name <- newIfaceName (mkVarOccFS fs)
+--           ; ty'  <- tcIfaceType ty
+--           ; return (mkLocalId name ty' `asJoinId_maybe` tcJoinInfo ji) }
+--    tc_pair (IfLetBndr _ _ info _, rhs) id
+--      = do { rhs' <- tcIfaceExpr rhs
+--           ; id_info <- tcIdInfo False {- Don't ignore prags; we are inside one! -}
+--                                 NotTopLevel (idName id) (idType id) info
+--           ; return (setIdInfo id id_info, rhs') }
+
+tcIfaceModGuts :: IfaceModGuts -> IfL ModGuts
+tcIfaceModGuts (IfaceModGuts f1 f2 f3 f4 f5 f6 f7 f8 f9 f10 f11 f12 f13 f14 f15 f16 f17 f18
+                        f19 f20 f21 f22 f23 f24 f25 f26 f27 f28 f29) = do
+  f10' <- mapM tcIfaceTyCon f10
+  f11' <- mapM tcIfaceInst f11
+  f12' <- mapM tcIfaceFamInst f12
+  f13' <- mapM tcIfacePatSyn f13
+  f14' <- mapM tcIfaceRule f14
+  f15' <- catMaybes <$> mapM (tcIfaceBinding f1 f3) f15
+  f23' <- extendInstEnvList emptyInstEnv <$> mapM tcIfaceInst f23
+  f24' <- extendFamInstEnvList emptyFamInstEnv <$> mapM tcIfaceFamInst f24
+
+  return $ ModGuts f1 f2 f3 f4 f5 f6 f7 f8 f9 f10' f11' f12' f13' f14' f15' f16 f17 f18
+                        f19 f20 f21 f22 f23' f24' f25 f26 f27 f28 f29
+
+  where
+    tcIfacePatSyn ps = do
+      decl <- tcIfaceDecl False ps
+      case decl of
+        AConLike (PatSynCon ps') -> return ps'
+        _                        -> panic "tcIfaceModGuts: a non-patsyn decl was stored in the patsyns field"

--- a/examples/extensible-interface-files/core-plugins/basic-example/Example.hs
+++ b/examples/extensible-interface-files/core-plugins/basic-example/Example.hs
@@ -1,0 +1,29 @@
+module Example where
+
+import GHC.Plugins
+import GHC.Iface.Load
+import GHC.Tc.Types
+import GHC.Tc.Utils.Monad
+
+import Control.Monad
+
+
+plugin :: Plugin
+plugin = defaultPlugin { installCoreToDos = corePlugin }
+
+
+corePlugin :: CorePlugin
+corePlugin _ = liftIfL . mapM inlineCore
+
+
+liftIfL :: IfL a -> CoreM a
+liftIfL m = do
+  env <- getHscEnv
+  mod <- getModule -- I think this is meant to be the module that is the source of the inlinings, not the current module
+  liftIO $
+    initIfaceLoad env $ -- This may have to load all dependencies, rather than the current module
+    initIfaceLcl mod (text "ExamplePlugin") False m
+
+
+inlineCore :: CoreToDo -> IfL CoreToDo
+inlineCore = return

--- a/examples/extensible-interface-files/core-plugins/basic-example/Example.hs
+++ b/examples/extensible-interface-files/core-plugins/basic-example/Example.hs
@@ -136,6 +136,7 @@ lookupName n bs = lookupNameEnv (mkNameEnvWith nameOf bs) n
 loadDependencies :: HscEnv
                  -> IO (Name -> Maybe (Bind CoreBndr))
 loadDependencies env = initIfaceLoad env $ do
+  liftIO $ print ("mods", length mods)
   binds <- forM mods $ \m -> do
     iface <- loadPluginInterface (text "lookupCore") m
     initIfaceLcl m (text "core") False $ loadCoreBindings iface

--- a/examples/extensible-interface-files/core-plugins/basic-example/Lib.hs
+++ b/examples/extensible-interface-files/core-plugins/basic-example/Lib.hs
@@ -2,18 +2,20 @@
 
 module Lib where
 
+a = 0
+b = a
 
-x, y :: Int
-x = 1
-y = x + 2
+-- x, y :: Int
+-- x = 1
+-- y = x + 2
 
-f = plus 1
-  where
-    plus = (+)
+-- f = plus 1
+--   where
+--     plus = (+)
 
-xs = ():xs
+-- xs = ():xs
 
-g :: Int -> Bool
-g 0 = True
-g _ = False
+-- g :: Int -> Bool
+-- g 0 = True
+-- g _ = False
 

--- a/examples/extensible-interface-files/core-plugins/basic-example/Lib.hs
+++ b/examples/extensible-interface-files/core-plugins/basic-example/Lib.hs
@@ -1,21 +1,24 @@
-{-# OPTIONS_GHC -fwrite-core-field #-}
+{-# OPTIONS_GHC -fplugin Example #-}
 
 module Lib where
 
+a, b :: Int
 a = 0
 b = a
 
--- x, y :: Int
--- x = 1
--- y = x + 2
+x, y :: Int
+x = 1
+y = x + 2
 
--- f = plus 1
---   where
---     plus = (+)
+f :: Int -> Int
+f = plus 1
+  where
+    plus = (+)
 
--- xs = ():xs
+xs :: [()]
+xs = ():xs
 
--- g :: Int -> Bool
--- g 0 = True
--- g _ = False
+g :: Int -> Bool
+g 0 = True
+g _ = False
 

--- a/examples/extensible-interface-files/core-plugins/basic-example/Lib.hs
+++ b/examples/extensible-interface-files/core-plugins/basic-example/Lib.hs
@@ -1,7 +1,6 @@
-{-# OPTIONS_GHC -fplugin Example #-}
+module Lib (f, xs, g, x, y, infinite, mapMyData, sumMyData, MyData(..)) where
 
-module Lib where
-
+-- Not exported, to test the serialised bindings
 a, b :: Int
 a = 0
 b = a
@@ -15,10 +14,30 @@ f = plus 1
   where
     plus = (+)
 
+-- Test for self-recursive bindings
 xs :: [()]
 xs = ():xs
 
+-- Test for multiple-equation bindings
 g :: Int -> Bool
 g 0 = True
 g _ = False
 
+infinite :: a -> [a]
+infinite x = x : infinite x
+
+data MyData a b
+   = Leaf a b
+   | Something Int (MyData a b)
+   | Pair (MyData a b) (MyData a b)
+   deriving Show
+
+mapMyData :: (a -> b -> (c, d)) -> MyData a b -> MyData c d
+mapMyData fn (Leaf x y)      = uncurry Leaf (fn x y)
+mapMyData fn (Something n x) = Something n (mapMyData fn x)
+mapMyData fn (Pair x1 x2)    = Pair (mapMyData fn x1) (mapMyData fn x2)
+
+sumMyData :: MyData a b -> Int
+sumMyData Leaf{}          = 0
+sumMyData (Something n x) = n + sumMyData x
+sumMyData (Pair x1 x2)    = sumMyData x1 + sumMyData x2

--- a/examples/extensible-interface-files/core-plugins/basic-example/Lib.hs
+++ b/examples/extensible-interface-files/core-plugins/basic-example/Lib.hs
@@ -1,5 +1,3 @@
-{-# OPTIONS_GHC -fplugin Example -fplugin-opt Example:inline #-}
-
 module Lib (f, xs, g, x, y, infinite, mapMyData, sumMyData, MyData(..)) where
 
 -- Prevent GHC from inlining the bindings from this module to demonstrate

--- a/examples/extensible-interface-files/core-plugins/basic-example/Lib.hs
+++ b/examples/extensible-interface-files/core-plugins/basic-example/Lib.hs
@@ -1,5 +1,18 @@
 module Lib (f, xs, g, x, y, infinite, mapMyData, sumMyData, MyData(..)) where
 
+-- Prevent GHC from inlining the bindings from this module to demonstrate
+-- the plugin doing so.
+{-# NOINLINE a         #-}
+{-# NOINLINE b         #-}
+{-# NOINLINE x         #-}
+{-# NOINLINE y         #-}
+{-# NOINLINE f         #-}
+{-# NOINLINE xs        #-}
+{-# NOINLINE g         #-}
+{-# NOINLINE infinite  #-}
+{-# NOINLINE mapMyData #-}
+{-# NOINLINE sumMyData #-}
+
 -- Not exported, to test the serialised bindings
 a, b :: Int
 a = 0

--- a/examples/extensible-interface-files/core-plugins/basic-example/Lib.hs
+++ b/examples/extensible-interface-files/core-plugins/basic-example/Lib.hs
@@ -1,0 +1,19 @@
+{-# OPTIONS_GHC -fwrite-core-field #-}
+
+module Lib where
+
+
+x, y :: Int
+x = 1
+y = x + 2
+
+f = plus 1
+  where
+    plus = (+)
+
+xs = ():xs
+
+g :: Int -> Bool
+g 0 = True
+g _ = False
+

--- a/examples/extensible-interface-files/core-plugins/basic-example/Lib.hs
+++ b/examples/extensible-interface-files/core-plugins/basic-example/Lib.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -fplugin Example -fplugin-opt Example:inline #-}
+
 module Lib (f, xs, g, x, y, infinite, mapMyData, sumMyData, MyData(..)) where
 
 -- Prevent GHC from inlining the bindings from this module to demonstrate

--- a/examples/extensible-interface-files/core-plugins/basic-example/Main.hs
+++ b/examples/extensible-interface-files/core-plugins/basic-example/Main.hs
@@ -1,0 +1,7 @@
+{-# OPTIONS_GHC -fplugin=Example #-}
+
+module Main where
+
+import Lib
+
+main = return ()

--- a/examples/extensible-interface-files/core-plugins/basic-example/Main.hs
+++ b/examples/extensible-interface-files/core-plugins/basic-example/Main.hs
@@ -1,7 +1,11 @@
-{-# OPTIONS_GHC -fplugin Example -fwrite-core-field #-}
+{-# OPTIONS_GHC -fplugin Example #-}
 
 module Main where
 
 import Lib
 
-main = return ()
+main :: IO ()
+main = print $ t x y
+
+t :: Int -> Int -> Bool
+t a b = g (f a + b)

--- a/examples/extensible-interface-files/core-plugins/basic-example/Main.hs
+++ b/examples/extensible-interface-files/core-plugins/basic-example/Main.hs
@@ -1,4 +1,4 @@
-{-# OPTIONS_GHC -fplugin=Example #-}
+{-# OPTIONS_GHC -fplugin Example -fwrite-core-field #-}
 
 module Main where
 

--- a/examples/extensible-interface-files/core-plugins/basic-example/Main.hs
+++ b/examples/extensible-interface-files/core-plugins/basic-example/Main.hs
@@ -1,5 +1,3 @@
-{-# OPTIONS_GHC -fplugin Example -fplugin-opt Example:inline #-}
-
 module Main where
 
 import Lib

--- a/examples/extensible-interface-files/core-plugins/basic-example/Main.hs
+++ b/examples/extensible-interface-files/core-plugins/basic-example/Main.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -fplugin Example -fplugin-opt Example:inline #-}
+
 module Main where
 
 import Lib

--- a/examples/extensible-interface-files/core-plugins/basic-example/Main.hs
+++ b/examples/extensible-interface-files/core-plugins/basic-example/Main.hs
@@ -1,11 +1,47 @@
-{-# OPTIONS_GHC -fplugin Example #-}
-
 module Main where
 
 import Lib
 
 main :: IO ()
-main = print $ t x y
+main = do
+
+  -- Simpler examples
+  print (t x y)
+  print (mapMyData fn_md md1)
+  print (sumMyData md1)
+
+  -- This example both tests the inliner's ability to correctly inline composed
+  -- functions and compares this being done within an expression with it being
+  -- done in a top-level binding.
+  print (sumMyData (mapMyData fn_md md1))
+  print (sumMapMyData md1)
 
 t :: Int -> Int -> Bool
 t a b = g (f a + b)
+
+md1 :: MyData Int Int
+md1 = Pair
+        (Pair (Leaf 1 2)
+              (Leaf 3 4))
+        (Pair (Something 5 (Leaf 6 7))
+              (Leaf 8 9))
+
+md2 :: MyData () ()
+md2 = Leaf () ()
+
+md3 :: MyData () ()
+md3 = Something 0 md2
+
+-- This structure is infinite on the last field, so we want to make sure that
+-- the inlining takes that into account and only inlines the first field.
+-- We should consider that Plutus will need to know about the infinite recursion
+-- when the AST is produced, so it's important that we can detect where this
+-- reference happens.
+md4 :: MyData () ()
+md4 = Pair md3 md4
+
+fn_md :: Int -> Int -> (Bool, Int)
+fn_md x y = (x == y, x + y)
+
+sumMapMyData :: MyData Int Int -> Int
+sumMapMyData x = sumMyData (mapMyData fn_md x)

--- a/examples/extensible-interface-files/core-plugins/basic-example/Makefile
+++ b/examples/extensible-interface-files/core-plugins/basic-example/Makefile
@@ -1,38 +1,39 @@
+# default to ghc, but allow us to override the compiler used by providing
+# HC, e.g. HC=/path/to/ghc-stage2 make ...
+HC ?= ghc
+# Same for HC_FLAGS (e.g. HC_FLAGS="-v").
+# We'll *always* add -dynamic to it though.
+#
+# Need -dynamic, otherwise ghc will complain.
+# it appears it defaults to loading dyn_o
+# plugins.
+#
+# <no location info>: fatal:
+#    cannot find object file ‘./Example.dyn_o’
+#    while linking an interpreted expression
+HC_FLAGS += -dynamic
 diff: vanilla core-inline
 	diff -u vanilla.core inlined.core
-
 vanilla:
-	ghc -odir vanilla -hidir vanilla -c Lib.hs
-	ghc -odir vanilla -hidir vanilla Main.hs -o VanillaMain -ddump-prep > vanilla.core
-
+	$(HC) $(HC_FLAGS) -odir vanilla -hidir vanilla -c Lib.hs
+	$(HC) $(HC_FLAGS) -odir vanilla -hidir vanilla Main.hs -o VanillaMain -ddump-prep > vanilla.core
 # I get a lot of errors with not being able to find modules properly if I use commands
 # like the vanilla version. This seems to work, but I would like to figure out what
 # causes the actual problem.
+#
+# There are a variety of bugs with plugins and locating them. Unless we package the
+# Example plugin into it's own package,  ghc will complain about
+#
+#   attempting to use module ‘main:Example’ (Example.hs) which is not loaded
+#
+# in the final linking step; which makes little sense.
 core-inline:
 	mkdir -p inlined
-	cd inlined; \
-		ghc -odir . -hidir . ../Example.hs -package ghc -dynamic; \
-		ghc -odir . -hidir . -fplugin Example -c ../Lib.hs -dynamic; \
-		ghc -odir . -hidir . -fplugin Example -c ../Main.hs -dynamic -o ../InlinedMain -ddump-prep > ../inlined.core
-
-# ghc -odir inlined -hidir inlined -fplugin Example -c Lib.hs -dynamic
-# <command line>: Could not find module ‘Example’
-core-inline-error1:
-	ghc -odir inlined -hidir inlined Example.hs -package ghc -dynamic
-	ghc -odir inlined -hidir inlined -fplugin Example -c Lib.hs -dynamic
-	ghc -odir inlined -hidir inlined -fplugin Example Main.hs -dynamic -o InlinedMain -ddump-prep > inlined.core
-
-# ghc -odir inlined -hidir inlined -fplugin Example -c Lib.hs -dynamic
-# Bad interface file: inlined/Example.hi
-#    inlined/Example.hi: openBinaryFile: does not exist (No such file or directory)
-core-inline-error2:
-	ghc Example.hs -package ghc -dynamic
-	ghc -odir inlined -hidir inlined -fplugin Example -c Lib.hs -dynamic
-	ghc -odir inlined -hidir inlined -fplugin Example Main.hs -dynamic -o InlinedMain -ddump-prep > inlined.core
-
+	cd inlined && $(HC) $(HC_FLAGS) -odir . -hidir . ../Example.hs -package ghc
+	cd inlined && $(HC) $(HC_FLAGS) -odir . -hidir . -fplugin Example -c ../Lib.hs
+	cd inlined && $(HC) $(HC_FLAGS) -odir . -hidir . -fplugin Example -c ../Main.hs -o ../InlinedMain -ddump-prep > ../inlined.core
 clean:
 	rm -rf vanilla inlined vanilla.core inlined.core VanillaMain InlinedMain
-
 # Launch ghcid for instant-feedback type-checking
 ghcid:
 	ghcid --command="ghci Main.hs Lib.hs Example.hs -package ghc"

--- a/examples/extensible-interface-files/core-plugins/basic-example/Makefile
+++ b/examples/extensible-interface-files/core-plugins/basic-example/Makefile
@@ -18,7 +18,7 @@ vanilla:
 	mkdir -p vanilla
 	cd vanilla && $(HC) $(HC_FLAGS) -odir . -hidir . ../Example.hs -package ghc
 	cd vanilla && $(HC) $(HC_FLAGS) -odir . -hidir . -fplugin Example -c ../Lib.hs
-	cd vanilla && $(HC) $(HC_FLAGS) -odir . -hidir . -fplugin Example -c ../Main.hs -o ../VanillaMain > ../vanilla.core
+	cd vanilla && $(HC) $(HC_FLAGS) -odir . -hidir . -fplugin Example -c ../Main.hs -o ../VanillaMain | tee ../vanilla.core
 # I get a lot of errors with not being able to find modules properly if I use commands
 # like the vanilla version. This seems to work, but I would like to figure out what
 # causes the actual problem.
@@ -33,7 +33,7 @@ core-inline:
 	mkdir -p inlined
 	cd inlined && $(HC) $(HC_FLAGS) -odir . -hidir . ../Example.hs -package ghc
 	cd inlined && $(HC) $(HC_FLAGS) -odir . -hidir . -fplugin Example -fplugin-opt Example:inline -c ../Lib.hs
-	cd inlined && $(HC) $(HC_FLAGS) -odir . -hidir . -fplugin Example -fplugin-opt Example:inline -c ../Main.hs -o ../InlinedMain > ../inlined.core
+	cd inlined && $(HC) $(HC_FLAGS) -odir . -hidir . -fplugin Example -fplugin-opt Example:inline -c ../Main.hs -o ../InlinedMain | tee ../inlined.core
 clean:
 	rm -rf vanilla inlined vanilla.core inlined.core VanillaMain InlinedMain
 # Launch ghcid for instant-feedback type-checking

--- a/examples/extensible-interface-files/core-plugins/basic-example/Makefile
+++ b/examples/extensible-interface-files/core-plugins/basic-example/Makefile
@@ -1,0 +1,23 @@
+diff: vanilla core-inline
+	diff -u vanilla.core inlined.core
+
+vanilla:
+	ghc -odir vanilla -hidir vanilla -c Lib.hs
+	ghc -odir vanilla -hidir vanilla Main.hs -o VanillaMain -ddump-prep > vanilla.core
+
+# I get a lot of errors with not being able to find modules properly if I use commands
+# like the vanilla version. This seems to work, but I would like to figure out what
+# causes the actual problem.
+core-inline:
+	mkdir -p inlined
+	cd inlined; \
+		ghc -odir . -hidir . ../Example.hs -package ghc -dynamic; \
+		ghc -odir . -hidir . -fplugin Example -c ../Lib.hs -dynamic; \
+		ghc -odir . -hidir . -fplugin Example -c ../Main.hs -dynamic -o ../InlinedMain -ddump-prep > ../inlined.core
+
+clean:
+	rm -rf vanilla inlined vanilla.core inlined.core VanillaMain InlinedMain
+
+# Launch ghcid for instant-feedback type-checking
+ghcid:
+	ghcid --command="ghci Main.hs Lib.hs Example.hs -package ghc"

--- a/examples/extensible-interface-files/core-plugins/basic-example/Makefile
+++ b/examples/extensible-interface-files/core-plugins/basic-example/Makefile
@@ -15,8 +15,10 @@ HC_FLAGS += -dynamic
 diff: vanilla core-inline
 	diff -u vanilla.core inlined.core
 vanilla:
-	$(HC) $(HC_FLAGS) -odir vanilla -hidir vanilla -c Lib.hs
-	$(HC) $(HC_FLAGS) -odir vanilla -hidir vanilla Main.hs -o VanillaMain -ddump-prep > vanilla.core
+	mkdir -p vanilla
+	cd vanilla && $(HC) $(HC_FLAGS) -odir . -hidir . ../Example.hs -package ghc
+	cd vanilla && $(HC) $(HC_FLAGS) -odir . -hidir . -fplugin Example -c ../Lib.hs
+	cd vanilla && $(HC) $(HC_FLAGS) -odir . -hidir . -fplugin Example -c ../Main.hs -o ../VanillaMain > ../vanilla.core
 # I get a lot of errors with not being able to find modules properly if I use commands
 # like the vanilla version. This seems to work, but I would like to figure out what
 # causes the actual problem.
@@ -30,8 +32,8 @@ vanilla:
 core-inline:
 	mkdir -p inlined
 	cd inlined && $(HC) $(HC_FLAGS) -odir . -hidir . ../Example.hs -package ghc
-	cd inlined && $(HC) $(HC_FLAGS) -odir . -hidir . -fplugin Example -c ../Lib.hs
-	cd inlined && $(HC) $(HC_FLAGS) -odir . -hidir . -fplugin Example -c ../Main.hs -o ../InlinedMain -ddump-prep > ../inlined.core
+	cd inlined && $(HC) $(HC_FLAGS) -odir . -hidir . -fplugin Example -fplugin-opt Example:inline -c ../Lib.hs
+	cd inlined && $(HC) $(HC_FLAGS) -odir . -hidir . -fplugin Example -fplugin-opt Example:inline -c ../Main.hs -o ../InlinedMain > ../inlined.core
 clean:
 	rm -rf vanilla inlined vanilla.core inlined.core VanillaMain InlinedMain
 # Launch ghcid for instant-feedback type-checking

--- a/examples/extensible-interface-files/core-plugins/basic-example/Makefile
+++ b/examples/extensible-interface-files/core-plugins/basic-example/Makefile
@@ -15,6 +15,21 @@ core-inline:
 		ghc -odir . -hidir . -fplugin Example -c ../Lib.hs -dynamic; \
 		ghc -odir . -hidir . -fplugin Example -c ../Main.hs -dynamic -o ../InlinedMain -ddump-prep > ../inlined.core
 
+# ghc -odir inlined -hidir inlined -fplugin Example -c Lib.hs -dynamic
+# <command line>: Could not find module ‘Example’
+core-inline-error1:
+	ghc -odir inlined -hidir inlined Example.hs -package ghc -dynamic
+	ghc -odir inlined -hidir inlined -fplugin Example -c Lib.hs -dynamic
+	ghc -odir inlined -hidir inlined -fplugin Example Main.hs -dynamic -o InlinedMain -ddump-prep > inlined.core
+
+# ghc -odir inlined -hidir inlined -fplugin Example -c Lib.hs -dynamic
+# Bad interface file: inlined/Example.hi
+#    inlined/Example.hi: openBinaryFile: does not exist (No such file or directory)
+core-inline-error2:
+	ghc Example.hs -package ghc -dynamic
+	ghc -odir inlined -hidir inlined -fplugin Example -c Lib.hs -dynamic
+	ghc -odir inlined -hidir inlined -fplugin Example Main.hs -dynamic -o InlinedMain -ddump-prep > inlined.core
+
 clean:
 	rm -rf vanilla inlined vanilla.core inlined.core VanillaMain InlinedMain
 

--- a/examples/extensible-interface-files/core-plugins/basic-example/README.md
+++ b/examples/extensible-interface-files/core-plugins/basic-example/README.md
@@ -1,24 +1,71 @@
 ## Motivation
 
+Plutus acts as an embedded-language compiler hosted within GHC Haskell to compile a Haskell program
+into a Plutus AST, which will then be used in code generation for programs to be run on the blockchain.
+
 In order to recover a Plutus AST from a Haskell function, the Plutus plugin inspects the Core of
 bindings to essentially inline the AST and provide that to the Plutus compiler. But, plugins are
 only fed the bindings of the current module, so we must recover the AST represented by any external
 names in a different way.
 
-This example project intends to show this process with extensible interface files.
+Currently, without extensible interface files, Plutus uses the unfoldings to recover the Core
+represented by a name from an external module. Unfoldings are normally used by GHC perform regular
+Haskell inlining. However, this has a number of disadvantages:
+* The user needs to annotate all such external bindings with `INLINE`
+* Alternately, the `-f-expose-all-unfoldings` flag can be used to equivalently generate unfoldings
+  for all bindings in a project or file
+* Annotating bindings with `INLINABLE` almost guarantees that a binding is inlined, so doing so
+  will very likely cause efficiency problems in code generation. Similarly, the presence of the
+  unfoldings produced by the flag also mess with GHC's inlining algorithm.
+
+Instead, we want to demonstrate a more semantically correct version of this using core bindings
+exposed in extensible interface files. Extensible interface files allow us to store arbirary
+serialisable data within the regular interface files, including data from a non-GHC source.
+Additionally, extensible interface files aim to give `.hi` files a more well-defined structure,
+so that external tools can interact with them. With this extensibility, we add a flag to GHC to
+serialise the `ModGuts` into an interface file field. The `ModGuts` represents the entire compilation
+state of a module after the Core pipeline has been run, before it's later converted to STG.
+Among other things, the `ModGuts` contains the core bindings for all exported definitions in a
+module.
+
+This example project intends to show the process of writing the core interface field, loading it
+within the `IfG a`/`IfL a` interface global/local loading environments, and finally using that data
+to lookup the right-hand sides of external names that appear in the core that is given in the plugin
+environment of the currently compiling module.
 
 ## Deliverables
 
 * Example structure of a plugin using extensible interface files and the `-fwrite-core-field` flag
-* Usage of loading `IfL` (interface load) monad environment into `CoreM` (core plugin) monad environment
+* Usage of loading the `IfG`/`IfL` (interface load) monad environments into `IO`, which can then be
+  lifted into the plugin action via `MonadIO`
 * Inlining the plugin binds based on the core recovered from interface files of dependencies
 
 ## Design and Implementation
+
+We define a `Lib` module, which contains stand-in definitions representing external bindings that
+would require being looked up if their names appeared in the right-hand sides of the definitions
+in another module. This module is compiled with the `-fwrite-core-field` flag, so its interface
+file will contain a field that can be deserialised into a `ModGuts`.
+
+Then, the `Lib` module is imported into the `Main` module, which then makes use of these imported
+definitions in its own definitions. `Main` is then compiled with the `Example` plugin, which
+performs a version of inlining to immitate Plutus. Because `Lib`'s definitions are external to
+`Main`, when the plugin encounters a name from `Lib`, it will have to recover the core from `Lib.hs`'s
+core extensible interface field.
+
+The `Example` module, containing the post-type checking plugin, makes use of the core found in
+interface files to perform a form of inlining to demonstrate usage for Plutus. The current module's
+bindings are found in the plugin argument, `TcGblEnv`, and the `TcM` monad in which the plugin
+operates gives us access to other environment data that we require to load interfaces.
+
+## Details
 
 * Loading interface files is done in the `type IfL a = IOEnv (Env IfGbl IfLcl) a` monad, while
   core plugins are in the `CoreM` enviroment. `IfL` is meant to be eventually run in `IO`, and
   `CoreM` is `MonadIO`, so it can be lifted into the plugin, but initialising the interface loading
   does require some extra data:
-  * The `HscEnv`, which can be retrieved from `getHscEnv`
-  * The `Module`s for each module that's a dependency of the one we're currently compiling, and
-    these potentially must be recovered 'manually' from their interface files
+  * We must first initialise the global enviroment, which requires the `HscEnv`, which can be
+    retrieved from `getHscEnv`. This `HscEnv` differs based on the current module being compiled
+  * For each external module that is being imported, the local enviroment must be initialised with
+    its `Module` data structure, essentially setting that one as active. These `Module`s are able
+    to be recovered from the module graph contained in the `HscEnv`

--- a/examples/extensible-interface-files/core-plugins/basic-example/README.md
+++ b/examples/extensible-interface-files/core-plugins/basic-example/README.md
@@ -69,3 +69,26 @@ operates gives us access to other environment data that we require to load inter
   * For each external module that is being imported, the local enviroment must be initialised with
     its `Module` data structure, essentially setting that one as active. These `Module`s are able
     to be recovered from the module graph contained in the `HscEnv`
+
+## Building
+
+### GHC
+
+With https://gitlab.haskell.org/ghc/ghc/-/tree/wip/coreField run:
+
+./boot
+./configure
+make -j8
+sudo make install
+
+Then include /usr/local/bin in the path.
+
+### This Package
+
+To build, run:
+
+ghc Main.hs -package ghc -dynamic
+
+To use ghcid, run:
+
+ghcid --command='ghci Main.hs -package ghc'

--- a/examples/extensible-interface-files/core-plugins/basic-example/README.md
+++ b/examples/extensible-interface-files/core-plugins/basic-example/README.md
@@ -76,12 +76,17 @@ operates gives us access to other environment data that we require to load inter
 
 With https://gitlab.haskell.org/ghc/ghc/-/tree/wip/coreField run:
 
+```
 ./boot
 ./configure
 make -j8
 sudo make install
+```
 
-Then include /usr/local/bin in the path.
+Then include export `/usr/local/bin` into the current session's path.
+
+Additionally, `configure` can be passed a `--prefix=/my/ghc/install/path` flag as an alternative
+to `/usr/local/bin`.
 
 ### This Package
 
@@ -89,6 +94,6 @@ To build, run:
 
 ghc Main.hs -package ghc -dynamic
 
-To use ghcid, run:
+To use ghcid for on-the-fly typechecking of this project, run:
 
 ghcid --command='ghci Main.hs -package ghc'

--- a/examples/extensible-interface-files/core-plugins/basic-example/README.md
+++ b/examples/extensible-interface-files/core-plugins/basic-example/README.md
@@ -1,0 +1,24 @@
+## Motivation
+
+In order to recover a Plutus AST from a Haskell function, the Plutus plugin inspects the Core of
+bindings to essentially inline the AST and provide that to the Plutus compiler. But, plugins are
+only fed the bindings of the current module, so we must recover the AST represented by any external
+names in a different way.
+
+This example project intends to show this process with extensible interface files.
+
+## Deliverables
+
+* Example structure of a plugin using extensible interface files and the `-fwrite-core-field` flag
+* Usage of loading `IfL` (interface load) monad environment into `CoreM` (core plugin) monad environment
+* Inlining the plugin binds based on the core recovered from interface files of dependencies
+
+## Design and Implementation
+
+* Loading interface files is done in the `type IfL a = IOEnv (Env IfGbl IfLcl) a` monad, while
+  core plugins are in the `CoreM` enviroment. `IfL` is meant to be eventually run in `IO`, and
+  `CoreM` is `MonadIO`, so it can be lifted into the plugin, but initialising the interface loading
+  does require some extra data:
+  * The `HscEnv`, which can be retrieved from `getHscEnv`
+  * The `Module`s for each module that's a dependency of the one we're currently compiling, and
+    these potentially must be recovered 'manually' from their interface files

--- a/examples/extensible-interface-files/core-plugins/basic-example/README.md
+++ b/examples/extensible-interface-files/core-plugins/basic-example/README.md
@@ -90,10 +90,9 @@ to `/usr/local/bin`.
 
 ### This Package
 
-To build, run:
-
-ghc Main.hs -package ghc -dynamic
-
-To use ghcid for on-the-fly typechecking of this project, run:
-
-ghcid --command='ghci Main.hs -package ghc'
+Makefile targets:
+* diff (default): build both with and without the plugin, and compare the resulting core
+* vanilla: build without the plugin, and output the core to vanilla.core
+* core-inline: build with the plugin, and output the core to inlined.core
+* clean: clean build results
+* ghcid: run ghcid to provide instant-feedback type-checking

--- a/examples/extensible-interface-files/core-plugins/basic-example/README.md
+++ b/examples/extensible-interface-files/core-plugins/basic-example/README.md
@@ -74,7 +74,7 @@ operates gives us access to other environment data that we require to load inter
 
 ### GHC
 
-With https://gitlab.haskell.org/ghc/ghc/-/tree/wip/coreField run:
+With https://gitlab.haskell.org/ghc/ghc/-/tree/wip/pluginExtFields run:
 
 ```
 ./boot


### PR DESCRIPTION
This is an example use case for the [Extensible Interface Files, ghc!2948](https://gitlab.haskell.org/ghc/ghc/-/merge_requests/2948) GHC extension.  The idea is to use store and load GHCs core representation from the interface files without having to resort to [`-fexpose-all-unfoldings`](https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/using-optimisation.html#ghc-flag--fexpose-all-unfoldings) or excessive [`INLINE` pragmas](https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/glasgow_exts.html#inline-and-noinline-pragmas). A high level overview is given in [README](https://github.com/input-output-hk/tools/blob/example-plugin/examples/extensible-interface-files/core-plugins/basic-example/README.md). 

[Example.hs](https://github.com/input-output-hk/tools/blob/example-plugin/examples/extensible-interface-files/core-plugins/basic-example/Example.hs) is the plugin code to be used with GHC, and which contains all the logic to write out, as well as read in the core expressions and inline them.

The setup consists of a [Lib](https://github.com/input-output-hk/tools/blob/example-plugin/examples/extensible-interface-files/core-plugins/basic-example/Lib.hs) module, and a [Main](https://github.com/input-output-hk/tools/blob/example-plugin/examples/extensible-interface-files/core-plugins/basic-example/Main.hs) module, where the `Main` module depends on the `Lib` module. Thus compiling the `Main` module with the `Example` plugin should demonstrate the inlining of core expressions.

NOTE: There is also a [Makefile](https://github.com/input-output-hk/tools/blob/example-plugin/examples/extensible-interface-files/core-plugins/basic-example/Makefile) that ties this all together and provides a reproducible setup.

### Discussion

The `Main` module contains the following function `t`:
https://github.com/input-output-hk/tools/blob/23c7b7c1d0d7fc4de649ebfe124a0ed2b5a7c329/examples/extensible-interface-files/core-plugins/basic-example/Main.hs#L19-L20

which we call in the `main` function of the `Main` module here:

https://github.com/input-output-hk/tools/blob/23c7b7c1d0d7fc4de649ebfe124a0ed2b5a7c329/examples/extensible-interface-files/core-plugins/basic-example/Main.hs#L6-L9

Thus to evaluate `t` we need `f`, `g` as well as `x` and `y`, from the `Lib` module.
https://github.com/input-output-hk/tools/blob/23c7b7c1d0d7fc4de649ebfe124a0ed2b5a7c329/examples/extensible-interface-files/core-plugins/basic-example/Lib.hs#L21-L23

https://github.com/input-output-hk/tools/blob/23c7b7c1d0d7fc4de649ebfe124a0ed2b5a7c329/examples/extensible-interface-files/core-plugins/basic-example/Lib.hs#L25-L28

https://github.com/input-output-hk/tools/blob/23c7b7c1d0d7fc4de649ebfe124a0ed2b5a7c329/examples/extensible-interface-files/core-plugins/basic-example/Lib.hs#L35-L37

(1) Without using the plugin we can see that the `Main` module produces the following core:
```
 main :: IO ()
 [LclIdX,
  Unf=Unf{Src=<vanilla>, TopLvl=True, Value=False, ConLike=False,
          WorkFree=False, Expandable=False, Guidance=IF_ARGS [] 570 0}]
 main
   = >>
       @IO
       $fMonadIO
       @()
       @()
       (print @Bool $fShowBool (g (+ @Int $fNumInt (f x) y)))
       (>>
          @IO
          $fMonadIO
          @()
          @()
          (print
             @(MyData Bool Int)
             ($fShowMyData @Bool @Int $fShowBool $fShowInt)
             (mapMyData @Int @Int @Bool @Int fn_md md1))
          (>>
             @IO
             $fMonadIO
             @()
             @()
             (print @Int $fShowInt (sumMyData @Int @Int md1))
             (>>
                @IO
                $fMonadIO
                @()
                @()
                (print
                   @Int
                   $fShowInt
                   (sumMyData @Bool @Int (mapMyData @Int @Int @Bool @Int fn_md md1)))
                (print
                   @Int
                   $fShowInt
                   (sumMyData
                      @Bool @Int (mapMyData @Int @Int @Bool @Int fn_md md1))))))
```
(2) when using the `Example` plugin, we observe that the `Main` modules core now looks like this: 
```
 main :: IO ()
 [LclIdX,
  Unf=Unf{Src=<vanilla>, TopLvl=True, Value=False, ConLike=False,
          WorkFree=False, Expandable=False, Guidance=IF_ARGS [] 670 0}]
 main
   = >>
       @IO
       $fMonadIO
       @()
       @()
       (print
          @Bool
          $fShowBool
          (case + @Int
                  $fNumInt
                  (+ @Int $fNumInt (I# 1#) (I# 1#))
                  (+ @Int $fNumInt x (I# 2#))
           of
           { I# ds ->
           case ds of {
             __DEFAULT -> False;
             0# -> True
           }
           }))
       (>>
          @IO
          $fMonadIO
          @()
          @()
          (print
             @(MyData Bool Int)
             ($fShowMyData @Bool @Int $fShowBool $fShowInt)
             (mapMyData @Int @Int @Bool @Int fn_md md1))
          (>>
             @IO
             $fMonadIO
             @()
             @()
             (print @Int $fShowInt (sumMyData @Int @Int md1))
             (>>
                @IO
                $fMonadIO
                @()
                @()
                (print
                   @Int
                   $fShowInt
                   (sumMyData @Bool @Int (mapMyData @Int @Int @Bool @Int fn_md md1)))
                (print
                   @Int
                   $fShowInt
                   (sumMyData
                      @Bool @Int (mapMyData @Int @Int @Bool @Int fn_md md1))))))
```

Please observe that we can see in (2), that the following expression from (1)
```
g (+ @Int $fNumInt (f x) y)
```
was replaced by
```
case + @Int
                  $fNumInt
                  (+ @Int $fNumInt (I# 1#) (I# 1#))
                  (+ @Int $fNumInt x (I# 2#))
           of
           { I# ds ->
           case ds of {
             __DEFAULT -> False;
             0# -> True
           }
           }
```

If we now treat `Lib` as it's own cabal package, this also works - with identical results. This is because the loading process is agnostic to package, so as long as the bindings exist, they will be loaded. In the case of one-shot compilation, modules appear as external anyway, so we would have to explicitly test for external package names if we wanted (for some reason) to exclude this working outside of the home package.